### PR TITLE
Allowing targeting of bundle min files

### DIFF
--- a/Meziantou.AspNetCore.BundleTagHelpers/BundleOptions.cs
+++ b/Meziantou.AspNetCore.BundleTagHelpers/BundleOptions.cs
@@ -7,12 +7,16 @@ namespace Meziantou.AspNetCore.BundleTagHelpers
         public bool UseMinifiedFiles { get; set; }
         public bool AppendVersion { get; set; }
 
+        // Property determining whether we'll target bundle.js or bundle.min.js file
+        public bool TargetBundleMinFile { get; set; }
+
         internal void Configure(IHostingEnvironment env)
         {
             if (env != null)
             {
                 UseMinifiedFiles = !env.IsDevelopment();
                 AppendVersion = !env.IsDevelopment();
+                TargetBundleMinFile = false;
             }
         }
     }

--- a/Meziantou.AspNetCore.BundleTagHelpers/BundleTagHelper.cs
+++ b/Meziantou.AspNetCore.BundleTagHelpers/BundleTagHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using BundlerMinifier;
 using Microsoft.AspNetCore.Hosting;
@@ -94,7 +95,17 @@ namespace Meziantou.AspNetCore.BundleTagHelpers
         {
             if (_options.UseMinifiedFiles)
             {
-                return new[] { bundle.OutputFileUrl };
+                var bundlePath = bundle.OutputFileUrl;
+                if (_options.TargetBundleMinFile)
+                {
+                    var extension = Path.GetExtension(bundlePath);
+                    if (extension != null)
+                    {
+                        bundlePath = Path.ChangeExtension(bundlePath, ".min" + extension);
+                    }
+                }
+
+                return new[] { bundlePath };
             }
 
             return bundle.InputFileUrls;


### PR DESCRIPTION
Hey @meziantou,

I like what you did - I just needed option to target min version of bundle so I've added it. Let me know if you can merge and publish NuGet update so that I can target new assembly in our solution.